### PR TITLE
Added exported option in the receiver.

### DIFF
--- a/carousalnotification/src/main/AndroidManifest.xml
+++ b/carousalnotification/src/main/AndroidManifest.xml
@@ -4,7 +4,8 @@
 
     <application android:allowBackup="true" android:label="@string/app_name"
         android:supportsRtl="true">
-        <receiver android:name=".CarousalEventReceiver">
+        <receiver android:name=".CarousalEventReceiver"
+                  android:exported="false">
             <intent-filter>
                 <action android:name="in.mamga.CAROUSALNOTIFICATIONFIRED"/>
             </intent-filter>


### PR DESCRIPTION
Project targeting API level 31 or higher requires this option.
explanation: 
If an activity, service, or broadcast receiver uses intent filters and doesn't have an explicitly-declared value for android:exported, your app can't be installed on a device that runs Android 12.
Refer this question for info: https://stackoverflow.com/questions/67412084/android-studio-error-manifest-merger-failed-apps-targeting-android-12